### PR TITLE
Set gotenberg timeout to 30s (PR vers develop)

### DIFF
--- a/pdfgen.php
+++ b/pdfgen.php
@@ -62,6 +62,7 @@ class pdfgen extends Plugins {
 
 			$client = new Client($this->_config['gotenberg_url']['value']);
 			$request = new URLRequest($article_url);
+			$request->setWaitTimeout(30);
 
 			$request->setPaperSize(Request::A4);
 			$request->setMargins(Request::NO_MARGINS);


### PR DESCRIPTION
30s est la valeur maximale de cette option pour gotenberg : https://gotenberg.dev/docs/6.x/environment_variables#maximum-wait-timeout

Voir https://github.com/chapitreneuf/pdfgen/issues/5